### PR TITLE
Add LogoutTest to validate redirect to login page

### DIFF
--- a/src/test/java/com/automationProject/pages/HomePage.java
+++ b/src/test/java/com/automationProject/pages/HomePage.java
@@ -3,6 +3,9 @@ package com.automationProject.pages;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.util.List;
 import java.util.Random;
@@ -12,6 +15,8 @@ public class HomePage {
 
     private By addToCartButton = By.className("btn_inventory");
     private By cartButton = By.className("shopping_cart_link");
+    private By sidebarButton = By.id("react-burger-menu-btn");
+    private By logoutButton = By.id("logout_sidebar_link");
 
     public HomePage(WebDriver driver) {
         this.driver = driver;
@@ -38,5 +43,17 @@ public class HomePage {
     public void navigateToCartPage() {
         WebElement navigateButton = driver.findElement(cartButton);
         navigateButton.click();
+    }
+
+    public void clickSidebarButton() {
+        WebElement sidebar = driver.findElement(sidebarButton);
+        sidebar.click();
+
+        WebDriverWait wait = new WebDriverWait(driver, 5);
+        wait.until(ExpectedConditions.visibilityOfElementLocated(logoutButton));
+    }
+    public void clickLogoutButton() {
+        WebElement logout = driver.findElement(logoutButton);
+        logout.click();
     }
 }

--- a/src/test/java/com/automationProject/tests/LogoutTest.java
+++ b/src/test/java/com/automationProject/tests/LogoutTest.java
@@ -1,0 +1,64 @@
+package com.automationProject.tests;
+
+import com.automationProject.pages.HomePage;
+import com.automationProject.pages.LoginPage;
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class LogoutTest {
+
+    private WebDriver driver;
+    private LoginPage loginPage;
+    private HomePage homePage;
+
+    @DataProvider
+    public Object[][] loginData() {
+        return new Object[][]{
+                {"standard_user", "secret_sauce"},
+                {"locked_out_user", "secret_sauce"},
+                {"problem_user", "secret_sauce"},
+                {"performance_glitch_user", "secret_sauce"},
+                {"error_user", "secret_sauce"},
+                {"visual_user", "secret_sauce"}
+        };
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        ChromeOptions options = new ChromeOptions();
+
+        options.addArguments("--incognito");
+
+        WebDriverManager.chromedriver().setup();
+        driver = new ChromeDriver(options);
+        driver.manage().window().maximize();
+        loginPage = new LoginPage(driver);
+        homePage = new HomePage(driver);
+    }
+
+    @Test(dataProvider = "loginData")
+    public void logOutTest(String email, String password) {
+
+        loginPage.goToLoginPage();
+        loginPage.loginValidUser(email, password);
+        Assert.assertEquals(driver.getCurrentUrl(), "https://www.saucedemo.com/inventory.html");
+
+        homePage.clickSidebarButton();
+        homePage.clickLogoutButton();
+        Assert.assertEquals(driver.getCurrentUrl(), "https://www.saucedemo.com/");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
**Description**

This PR introduces a logout flow test to ensure that users are correctly redirected to the login page after logging out.

**Implementation details**

Implemented LogoutTest using TestNG.

Utilized a DataProvider to test the logout functionality across multiple user accounts.

Reused existing Page Object Model (POM) structure (LoginPage, HomePage).

Validated that after logout, the URL matches the login page (https://www.saucedemo.com/).

Browser setup handled with @BeforeMethod and teardown with @AfterMethod.

Executed tests in incognito mode for isolation.

**Verification**

Log in with each user provided in the DataProvider.

Open the sidebar menu and trigger the logout action.

Confirm redirection to the login page.